### PR TITLE
Quote the arguments when forwarding

### DIFF
--- a/good-cat
+++ b/good-cat
@@ -9,4 +9,4 @@
 command -v cat >/dev/null 2>&1 || exit 1
 
 # Otherwise, run 'cat'
-exec cat $@
+exec cat "$@"


### PR DESCRIPTION
Here's why this is needed:

```
$ touch '1 2 3'
$ cat -n '1 2 3' # works as expected
$ sh good-cat -n '1 2 3' # doesn't retain $IFS characters in file names
cat: 1: Нет такого файла или каталога
cat: 2: Нет такого файла или каталога
cat: 3: Нет такого файла или каталога
```