### PR TITLE
Allow pipes if used for concat or text processing

### DIFF
--- a/good-cat
+++ b/good-cat
@@ -3,7 +3,7 @@
 # This cat hates pipes.
 
 # Exit with an error if output is piped
-[ -t 1 ] || exit 1
+[ -t 1 -o $# -ne 1 ] || exit 1
 
 # Exit with an error if 'cat' doesn't exist
 command -v cat >/dev/null 2>&1 || exit 1


### PR DESCRIPTION
The common pattern of useless `cat` piping is `cat filename | command …`, but there are useful cases for piping `cat`. It appears that any useless usage of `cat` has one argument. So when the number of arguments is not 1, it is not useless use of `cat`.

Known issues:

This will still block this useful pattern:

	command | cat -v | command